### PR TITLE
Rename the addon in the TOC

### DIFF
--- a/LucidNightmareNavigator.toc
+++ b/LucidNightmareNavigator.toc
@@ -1,10 +1,10 @@
 ## Interface: 70300
-## Title: Lucid Nightmare Helper+
+## Title: Lucid Nightmare Navigator
 ## Author: Wonderpants US - Thrall
 ## Notes: Directs you through the Endless Halls maze
 ## eMail: wpants@hardmodecode.com
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
-## SavedVariables: 
+## SavedVariables:
 libs\NyxGUI-1.0\NyxGUI.xml
 LucidNightmareNavigator.lua


### PR DESCRIPTION
Looks like this got missed in the `Lucid Nightmare Helper+` -> `Lucid Nightmare Navigator` rename.
